### PR TITLE
:bug: Fix: 修复 Katex 逻辑 & 上一篇文章图片懒加载问题

### DIFF
--- a/module/widget/prev_next_page.ftl
+++ b/module/widget/prev_next_page.ftl
@@ -3,7 +3,7 @@
         <div class="nav previous">
             <#if prevPost??>
                 <#if prevPost.thumbnail?? && prevPost.thumbnail!=''>
-                    <img class="lazyloaded" src="${theme_base!}/source/images/loading.svg" data-src="${prevPost.thumbnail}" alt="${prevPost.title!}" />
+                    <img class="lazyload" src="${theme_base!}/source/images/loading.svg" data-src="${prevPost.thumbnail}" alt="${prevPost.title!}" />
                 <#elseif settings.card_random_cover_list?? && settings.card_random_cover_list != ''>
                     <img class="img-random lazyloaded" index="${.now?string['ss']?number - 1}" src="${theme_base!}/source/images/loading.svg"
                          alt="${prevPost.title!}"/>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -306,7 +306,7 @@ var inlineReg = /\$([\s\S]*?)\$/g;
 function formatMath(kateBlock, isBlock) {
     // 这一步很重要，需要把 &amp; 换成 &
     var block = kateBlock.replaceAll("&amp;", "&");
-    if (block.length < 4) {
+    if (block.length < 3) {
         return;
     }
     var len = isBlock ? 2 : 1;


### PR DESCRIPTION
修复 Katex 逻辑 #123 
修复上一篇文章图片懒加载问题 #126 
经测试，将 `img` 标签中 `class` 修改为 `"lazyloaded"` 反而会导致懒加载失败：

![](https://i.loli.net/2021/02/04/6eEZYCqhrpRDSwF.png)

原问题应该是其他原因引起的。

还原为 `"lazyload"` 后懒加载正常：

![](https://i.loli.net/2021/02/04/WgTdRO54zPIiput.png)