### PR TITLE
更新 Katex 版本，使用 auto-render 载入公式 & 自言时间修复为 24 小时制

### DIFF
--- a/journals.ftl
+++ b/journals.ftl
@@ -29,7 +29,7 @@
                                     <span class="ziyan-username">${user.nickname!}</span>
                                     <span class="is-verified-badge"></span>
                                     <span class="ziyan-text">·</span>
-                                    <span class="ziyan-date time-ago" time="${journal.createTime?string("yyyy-MM-dd hh:mm:ss")}"></span>
+                                    <span class="ziyan-date time-ago" time="${journal.createTime?string("yyyy-MM-dd HH:mm:ss")}"></span>
                                 </div>
                                 <div class="ziyan-body markdown-body md-content">
                                     ${journal.content!}

--- a/module/script.ftl
+++ b/module/script.ftl
@@ -15,9 +15,12 @@
 </#if>
 
 <#if settings.enabled_mathjax!true>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
-            integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
-            crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.2/dist/katex.min.js"
+                  integrity="sha384-1Or6BdeNQb0ezrmtGeqQHFpppNd7a/gw29xeiSikBbsb44xu3uAo8c7FwbF5jhbd"
+                  crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.2/dist/contrib/auto-render.min.js"
+                  integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl"
+                  crossorigin="anonymous"></script>
 </#if>
 
 

--- a/module/styles.ftl
+++ b/module/styles.ftl
@@ -76,8 +76,8 @@
 </#if>
 <#if settings.enabled_mathjax!true>
   <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
-        integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X"
+        href="https://cdn.jsdelivr.net/npm/katex@0.13.2/dist/katex.min.css"
+        integrity="sha384-Cqd8ihRLum0CCg8rz0hYKPoLZ3uw+gES2rXQXycqnL5pgVQIflxAUDS7ZSjITLb5"
         crossorigin="anonymous">
 </#if>
 <#if settings.Aplayer?? && settings.Aplayer != ''>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -785,7 +785,7 @@ function timeAgo(time) {
     if (days < 1) {
         return days + ' 天前'
     } else {
-        return formatDate(time, 'yyyy/MM/dd hh:mm');
+        return formatDate(time, 'yyyy/MM/dd HH:mm');
     }
 }
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -358,7 +358,7 @@ function formatContent() {
     // 反转义原始markdown文本
     originalContent = HTMLDecode(originalContent);
     // 处理公式， 这是主要是因为 \\ 的原因
-    originalContent = dealMathx(originalContent);
+    // originalContent = dealMathx(originalContent);
     persentContent.empty();
     persentContent.addClass("loading");
 
@@ -490,13 +490,13 @@ function formatContent() {
     highlightCode();
 
     // 相册
-    loadGallery()
+    loadGallery();
 
     // 数学公式
-    // renderMath()
+    renderMath();
 
     // 图片懒加载
-    lazyloadImg()
+    lazyloadImg();
     return true;
 }
 
@@ -681,13 +681,22 @@ function getMore(e) {
 /**
  * 渲染数学公式
  */
+ const katexConfig = {
+    leqno: true,
+    delimiters: [
+        {left: "$$", right: "$$", display: true},
+        {left: "$", right: "$", display: false},
+        {left: "\\(", right: "\\)", display: false},
+        {left: "\\[", right: "\\]", display: true}
+    ]
+}
 function renderMath() {
     if (openKatex && renderMathInElement && typeof renderMathInElement
         !== 'undefined') {
         if (document.getElementById('write')) {
-            renderMathInElement(document.getElementById('write'), katex_config)
+            renderMathInElement(document.getElementById('write'), katexConfig);
         } else if (document.getElementById('ziyan')) {
-            renderMathInElement(document.getElementById('ziyan'), katex_config)
+            renderMathInElement(document.getElementById('ziyan'), katexConfig);
         }
     }
 }


### PR DESCRIPTION
#140

`\\` 可以用 `\\\` 或 `\newline` 代替，`$...$` 和 `$$...$$` 直接正则替换在一些场景下会造成问题。

如：

```markdown
# $ text
text
$
```

没有合适的 markdwon-tex-render，故重新改回 katex-auto-render。