### PR TITLE
markdown渲染问题修复

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -482,7 +482,7 @@ function formatContent() {
 
     persentContent.empty();
     persentContent.removeClass("loading");
-    persentContent.html(marked(originalContent.trim()));
+    persentContent.html(marked.parse(originalContent.trim()));
 
     mdContent.remove();
     mdContent = null;


### PR DESCRIPTION
正文markdown文章渲染不出来，js报错：Uncaught TypeError: marked is not a function

问题原因：markedjs更新至4.0.0版本，取消了marked()方法，用marked.parse(...)替代https://github.com/markedjs/marked/releases