### PR TITLE
⚡️ Update: 固定markdown插件版本

### DIFF
--- a/module/plugins.ftl
+++ b/module/plugins.ftl
@@ -1,5 +1,5 @@
 <!-- markdown 插件 -->
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@4.0.0/marked.min.js"></script>
 
 <!--图片预览插件-->
 <#if settings.enable_image_view!false>


### PR DESCRIPTION
避免再次出现版本更新后API修改导致文章无法渲染的Bug